### PR TITLE
Add --prefix and --suffix options for customizable include guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Introduced `--prefix` option for customizing the prefix of the include guard (default: `"UUID"`).
+- Introduced `--suffix` option for appending a suffix to the include guard (default: none).
+- Supported combining `--prefix` and `--suffix` for full customization.
 - Introduced the `clap` crate (version 4.5.27) for argument parsing.
   - Added `--output`/`-o` and `--overwrite` options with `clap`.
   - Enabled `derive` feature for `clap` in `Cargo.toml`.
 
 ### Changed
+
 - Replaced custom argument parsing logic in `src/main.rs` with `clap`.
   - Improved maintainability and readability by leveraging `clap`'s features.
 - Updated `Cargo.lock` to include new dependencies related to `clap`.
 
 ### Removed
+
 - Deprecated manual argument parsing using `std::env::args()` in favor of `clap`.
 


### PR DESCRIPTION
### Description

This pull request introduces the following changes:

#### Major Changes:
1. **New Options for Include Guards**:
   - Added `--prefix` option to customize the prefix of the include guard.
     - Default: `"UUID"`.
     - Allows users to prepend a custom prefix to the UUID in the include guard.
   - Added `--suffix` option to append a suffix to the include guard.
     - Default: none (only added if explicitly specified).
   - Supported combining both `--prefix` and `--suffix` for full customization.

2. **Updated `generate_guard` Function**:
   - Refactored to dynamically construct include guards using the `--prefix` and `--suffix` options.
   - Components of the include guard are joined with underscores for consistency.

3. **Updated `CHANGELOG.md`**:
   - Documented the introduction of `--prefix` and `--suffix` options in the `Added` section.
   - Improved readability and alignment with Keep a Changelog guidelines.

#### Default Behavior Example:
If no `--prefix` or `--suffix` is specified:
```c
#ifndef UUID_12345678_ABCD_EF01_234567890ABC
#define UUID_12345678_ABCD_EF01_234567890ABC
#endif /* UUID_12345678_ABCD_EF01_234567890ABC */
```

#### Example with `--prefix` and `--suffix`:
Command:
```bash
./guardgen --prefix MY_PREFIX --suffix MY_SUFFIX
```

Output:
```c
#ifndef MY_PREFIX_12345678_ABCD_EF01_234567890ABC_MY_SUFFIX
#define MY_PREFIX_12345678_ABCD_EF01_234567890ABC_MY_SUFFIX
#endif /* MY_PREFIX_12345678_ABCD_EF01_234567890ABC_MY_SUFFIX */
```

---

### How to Test

1. Build the project:
   ```sh
   cargo build
   ```
2. Test the CLI options:
   - Run with `--prefix` to ensure the prefix is added.
   - Run with `--suffix` to ensure the suffix is appended.
   - Combine `--prefix` and `--suffix` to confirm they work together.
3. Verify the generated include guards match the expected format.
4. Check the `CHANGELOG.md` for accurate documentation of changes.

---

### Checklist

- [x] Code compiles without warnings or errors.
- [x] CLI options (`--prefix` and `--suffix`) function as intended.
- [x] Include guard format is consistent and correct.
- [x] `CHANGELOG.md` is updated with the new features.
