### PR TITLE
Add `-x` option to specify target language for include guard generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced `--prefix` option for customizing the prefix of the include guard (default: `"UUID"`).
 - Introduced `--suffix` option for appending a suffix to the include guard (default: none).
 - Supported combining `--prefix` and `--suffix` for full customization.
+- Introduced `-x` option to specify the target language for include guard generation.
+  - Supported values: `none` (default), `c`, and `cxx`.
+  - Added `extern "C" {}` block when targeting C with `-x c`.
 - Introduced the `clap` crate (version 4.5.27) for argument parsing.
   - Added `--output`/`-o` and `--overwrite` options with `clap`.
   - Enabled `derive` feature for `clap` in `Cargo.toml`.
@@ -25,4 +28,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Deprecated manual argument parsing using `std::env::args()` in favor of `clap`.
-


### PR DESCRIPTION
### Description

This pull request introduces the following changes:

#### **Major Features:**
1. **`-x` Option for Target Language:**
   - Added a new `-x` option to specify the target language for include guard generation.
   - Supported values:
     - `none` (default): No additional language-specific output.
     - `c`: Adds an `extern "C" {}` block for compatibility with C code.
     - `cxx`: Explicitly targets C++ but does not add extra output.
   - This enhances flexibility for multi-language environments.

2. **Updates to `generate_guard` Function:**
   - Modified to dynamically construct include guards based on the `-x` option.
   - Adds language-specific blocks (e.g., `extern "C" {}`) only when targeting C with `-x c`.

3. **Updated `CHANGELOG.md`:**
   - Added documentation for the new `-x` option under the `Added` section.
   - Ensured alignment with the Keep a Changelog guidelines.

---

### Examples

1. **Default Behavior (`none`):**
   ```bash
   ./guardgen
   ```
   Output:
   ```c
   #ifndef UUID_12345678_ABCD_EF01_234567890ABC
   #define UUID_12345678_ABCD_EF01_234567890ABC

   #endif /* UUID_12345678_ABCD_EF01_234567890ABC */
   ```

2. **C Target (`-x c`):**
   ```bash
   ./guardgen -x c
   ```
   Output:
   ```c
   #ifndef UUID_12345678_ABCD_EF01_234567890ABC
   #define UUID_12345678_ABCD_EF01_234567890ABC

   #ifdef __cplusplus
   extern "C" {
   #endif /* __cplusplus */

   #ifdef __cplusplus
   } /* extern "C" */
   #endif /* __cplusplus */

   #endif /* UUID_12345678_ABCD_EF01_234567890ABC */
   ```

3. **C++ Target (`-x cxx`):**
   ```bash
   ./guardgen -x cxx
   ```
   Output:
   ```c
   #ifndef UUID_12345678_ABCD_EF01_234567890ABC
   #define UUID_12345678_ABCD_EF01_234567890ABC

   #endif /* UUID_12345678_ABCD_EF01_234567890ABC */
   ```

---

### How to Test

1. Build the project:
   ```bash
   cargo build
   ```
2. Test the CLI with different `-x` values:
   - Default (`-x none` or no `-x` specified): Generates a plain include guard.
   - `-x c`: Verifies the inclusion of `extern "C" {}` for C compatibility.
   - `-x cxx`: Ensures no additional output but targets C++ explicitly.
3. Validate the generated include guards for correctness.

---

### Checklist

- [x] Code compiles without errors or warnings.
- [x] The `-x` option works as expected for all supported values.
- [x] Include guard output is consistent with the specified language.
- [x] `CHANGELOG.md` is updated to reflect the new feature.
