### PR TITLE
Add `--line-ending` option to control line endings in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced `-x` option to specify the target language for include guard generation.
   - Supported values: `none` (default), `c`, and `cxx`.
   - Added `extern "C" {}` block when targeting C with `-x c`.
+- Introduced `--line-ending` option to control line endings in the generated output.
+  - Supported values: `LF`, `CRLF`, and `None` (default: system standard).
+  - Automatically detects and uses the appropriate line ending if `None` is specified.
 - Introduced the `clap` crate (version 4.5.27) for argument parsing.
   - Added `--output`/`-o` and `--overwrite` options with `clap`.
   - Enabled `derive` feature for `clap` in `Cargo.toml`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,13 @@ enum Language {
     Cxx,
 }
 
+#[derive(Clone, Debug, ValueEnum)]
+enum LineEnding {
+    None,
+    LF,
+    CRLF,
+}
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -33,9 +40,17 @@ struct Args {
 
     #[arg(short, value_enum, default_value_t = Language::None, ignore_case = true)]
     x: Language,
+
+    #[arg(long="line-ending", value_enum, default_value_t = LineEnding::None, ignore_case=true)]
+    line_ending: LineEnding,
 }
 
-fn generate_guard(prefix: String, suffix: Option<String>, x: Language) -> String {
+fn generate_guard(
+    prefix: String,
+    suffix: Option<String>,
+    x: Language,
+    line_ending: LineEnding,
+) -> String {
     let uuid = uuid7::uuid7().to_string().replace('-', "_").to_uppercase();
     let mut guard = vec![prefix, uuid];
     if let Some(suffix) = suffix {
@@ -68,13 +83,26 @@ fn generate_guard(prefix: String, suffix: Option<String>, x: Language) -> String
     text.push(endif);
     text.push("".to_string());
 
-    text.join("\n")
+    let newline = match line_ending {
+        LineEnding::LF => "\n",
+        LineEnding::CRLF => "\r\n",
+        _ => {
+            if cfg!(target_os = "windows") {
+                "\r\n"
+            } else {
+                "\n"
+            }
+        }
+    }
+    .to_string();
+
+    text.join(&newline)
 }
 
 fn main() {
     let args = Args::parse();
 
-    let guard = generate_guard(args.prefix, args.suffix, args.x);
+    let guard = generate_guard(args.prefix, args.suffix, args.x, args.line_ending);
 
     if let Some(file_path) = &args.filename {
         if !args.overwrite && fs::metadata(file_path).is_ok() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ enum Language {
     Cxx,
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, ValueEnum)]
 enum LineEnding {
     None,


### PR DESCRIPTION

### Description

This pull request introduces the following changes:

#### **Major Changes:**
1. **`--line-ending` Option:**
   - Added a new `--line-ending` option to control the line ending style in the generated output.
   - Supported values:
     - `LF`: Use Unix-style line endings (`\n`).
     - `CRLF`: Use Windows-style line endings (`\r\n`).
     - `None` (default): Automatically detects and uses the system's standard line ending.

2. **Updates to `generate_guard` Function:**
   - Refactored the function to apply the selected line ending style when joining output lines.
   - Ensured consistent formatting across platforms.

3. **Clippy Warning Suppression:**
   - Added `#[allow(clippy::upper_case_acronyms)]` to suppress the `upper_case_acronyms` warning for the `LineEnding` enum.
   - Maintained `LF` and `CRLF` in uppercase for clarity and consistency.

4. **Updated `CHANGELOG.md`:**
   - Documented the new `--line-ending` option in the `Added` section.

---

### How to Test

1. Build the project:
   ```bash
   cargo build
   ```
2. Test the `--line-ending` option with different values (`LF`, `CRLF`, and `None`) to ensure correct output.
3. Verify the default behavior correctly detects the system's standard line ending.

---

### Checklist

- [x] Code compiles without errors or warnings.
- [x] `--line-ending` option works as intended with all supported values.
- [x] Suppressed Clippy warnings for `LineEnding` enum.
- [x] Updated `CHANGELOG.md` to reflect the new feature.
