### PR TITLE
Improve `-h` Option Help Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved help messages for the `-h` option.
+  - Added `long_about` to provide a detailed overview of the tool.
+  - Enhanced `help` descriptions for all command-line arguments.
+  - Clarified language options (`none`, `c`, `cxx`) and line-ending styles (`none`, `lf`, `crlf`).
+
 ---
 
 ## [1.1.0] - 2025-01-28

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,24 +25,64 @@ enum LineEnding {
 }
 
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(
+    author = "Daisuke Nagao",
+    version,
+    about = "Generates include guards with optional UUID-based naming.",
+    long_about = "This tool generates unique include guards for C/C++ header files.\n\
+                  The guard name is based on a UUID and optional prefix/suffix.\n\
+                  It supports different languages and line-ending formats.\n\
+                  The output can be printed to stdout or written to a file."
+)]
 struct Args {
-    #[arg(short = 'o', long = "output")]
+    /// Output filename (if omitted, prints to stdout)
+    #[arg(
+        short = 'o',
+        long = "output",
+        help = "Specify the output file. If omitted, prints to stdout."
+    )]
     filename: Option<String>,
 
-    #[arg(long, default_value_t = false)]
+    /// Overwrite existing file if specified
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Overwrite the output file if it already exists."
+    )]
     overwrite: bool,
 
-    #[arg(long = "prefix", default_value = "UUID")]
+    /// Prefix for the include guard (default: "UUID")
+    #[arg(
+        long = "prefix",
+        default_value = "UUID",
+        help = "Specify a prefix for the include guard. Default: 'UUID'."
+    )]
     prefix: String,
 
-    #[arg(long = "suffix", default_value = None)]
+    /// Suffix for the include guard (optional)
+    #[arg(long = "suffix", default_value = None, help = "Specify an optional suffix for the include guard.")]
     suffix: Option<String>,
 
-    #[arg(short, value_enum, default_value_t = Language::None, ignore_case = true)]
+    /// Language format (C/C++ specific adjustments)
+    #[arg(
+        short,
+        value_enum,
+        default_value_t = Language::None,
+        ignore_case = true,
+        help = "Specify the language for compatibility adjustments. \
+                Options: none (default), c (adds extern \"C\" blocks), cxx (no additional modification)."
+    )]
     x: Language,
 
-    #[arg(long="line-ending", value_enum, default_value_t = LineEnding::None, ignore_case=true)]
+    /// Line-ending style (LF/CRLF)
+    #[arg(
+        long = "line-ending",
+        value_enum,
+        default_value_t = LineEnding::None,
+        ignore_case = true,
+        help = "Specify the line-ending style. \
+                Options: none (auto-detect), lf (Unix-style LF), crlf (Windows-style CRLF)."
+    )]
     line_ending: LineEnding,
 }
 


### PR DESCRIPTION
Improve `-h` Option Help Messages

**Description:**
This PR improves the help messages displayed with the `-h` option by enhancing argument descriptions and adding a long-form overview of the tool. The changes aim to make the CLI more user-friendly and self-explanatory.

**Changes:**
- **Updated `long_about`**: Added a detailed tool description explaining its functionality and usage.
- **Enhanced argument help messages**:
  - `-o, --output`: Now explicitly states that the output file is optional and prints to stdout by default.
  - `--overwrite`: Clarified that it allows overwriting an existing file.
  - `--prefix`: Now includes a default value (`"UUID"`) in the help text.
  - `--suffix`: Explicitly mentions that it is optional.
  - `-x`: Lists available options (`none`, `c`, `cxx`) and their effects.
  - `--line-ending`: Clearly describes available line-ending styles (`none`, `lf`, `crlf`).
- **Formatted help messages**: Improved readability and consistency across all options.

**Related Issue:** #10 (Feature Request: Improve `-h` Option Help Message)

**Checklist:**
- [x] Tested help output via `cargo run -- -h`
- [x] Verified correct formatting of descriptions
- [x] Updated `CHANGELOG.md` with details of the improvement

**How to Test:**
1. Run `cargo run -- -h`
2. Verify that the output includes well-structured descriptions for all options.
3. Ensure that no breaking changes were introduced.

