### PR TITLE
Title: Improve error handling for file operations in `main.rs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `long_about` to provide a detailed overview of the tool.
   - Enhanced `help` descriptions for all command-line arguments.
   - Clarified language options (`none`, `c`, `cxx`) and line-ending styles (`none`, `lf`, `crlf`).
+- Improved error handling for file operations.
+  - Added specific error handling for `AlreadyExists` and `PermissionDenied` cases.
+  - Improved error messages to provide clearer feedback on file operation failures.
 
 ---
 


### PR DESCRIPTION

**Description:**  
This PR improves error handling for file operations in `main.rs`, ensuring more specific and informative error messages when writing to a file.

**Changes:**  
- Added specific error handling for `AlreadyExists` and `PermissionDenied` cases.
- Improved error messages to provide clearer feedback when file creation fails.
- Ensured consistent formatting and readability in error-handling logic.

**Related Issue:** #12 (Improve error handling for `OpenOptions` in `main.rs`)

**Checklist:**  
- [x] Tested file creation with different error scenarios (`AlreadyExists`, `PermissionDenied`).
- [x] Verified that error messages are correctly displayed in each case.
- [x] Updated `CHANGELOG.md` with details of the improvement.

**How to Test:**  
1. Run the tool with an existing file and no `--overwrite` flag to trigger the `AlreadyExists` error.
2. Try writing to a file in a restricted directory to trigger the `PermissionDenied` error.
3. Verify that other file creation errors are still handled properly.
