### PR TITLE
Refactor enums, enhance WebAssembly support, and update dependencies

### DIFF
--- a/.github/workflows/rust-ci-preview.yml
+++ b/.github/workflows/rust-ci-preview.yml
@@ -15,8 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        os: 
-          - macos-26 
+        os:
+          - macos-26
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: 
+        os:
           - ubuntu-latest
           - windows-latest
           - ubuntu-24.04-arm

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@ repos:
     -   id: check-yaml
     -   id: check-toml
     -   id: check-added-large-files
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: fmt
+    -   id: cargo-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-toml
+    -   id: check-added-large-files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bumpalo"
@@ -86,21 +86,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -120,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -143,25 +132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,18 +144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "forkguard"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bab9e346d9936120193360409a5ef77c7fb32ad20322aae22ce7994678713c"
-
-[[package]]
-name = "fstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390f4f9e50e38200d6f446be02569f1784e5ce19d7c1aa3f1ff55a885d0d9d18"
-
-[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,7 +153,6 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -206,14 +163,11 @@ name = "guardgen"
 version = "1.2.1"
 dependencies = [
  "clap",
- "console_error_panic_hook",
  "getrandom",
  "js-sys",
- "once_cell",
  "regex",
- "uuid7",
+ "uuid",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -227,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -245,12 +199,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -285,9 +239,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "log"
@@ -348,29 +302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,15 +329,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "reseeding_rng"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd71575b08040a946d6b0850fd0d3c1d9e0d698ab9cc7da1c5cd8bea4f69a12f"
-dependencies = [
- "rand_core 0.10.1",
-]
 
 [[package]]
 name = "rustversion"
@@ -498,16 +420,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid7"
-version = "1.7.0"
+name = "uuid"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940941b348b517b0d6ccbec038976a5a8c1a1caf811f25f1b79432f90fec8ff5"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "forkguard",
- "fstr",
- "rand",
- "rand_core 0.6.4",
- "reseeding_rng",
+ "getrandom",
+ "js-sys",
+ "uuid-rng-internal",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-rng-internal"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1409d2323564d9b8d01192a77a0604a46bf29eb42e9b535aca34dec65482652b"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -605,16 +535,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,11 +182,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -188,8 +196,10 @@ name = "guardgen"
 version = "1.2.1"
 dependencies = [
  "clap",
+ "getrandom",
  "regex",
  "uuid7",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -244,6 +254,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +286,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -367,6 +393,12 @@ checksum = "bd71575b08040a946d6b0850fd0d3c1d9e0d698ab9cc7da1c5cd8bea4f69a12f"
 dependencies = [
  "rand_core 0.10.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -480,6 +512,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -144,6 +144,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -199,12 +223,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -223,10 +247,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -239,9 +265,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
@@ -266,6 +292,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prettyplease"
@@ -385,6 +417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,11 +480,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -455,14 +493,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -473,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -483,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -496,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -560,6 +598,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -93,7 +93,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -143,6 +143,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,7 +195,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -196,10 +206,14 @@ name = "guardgen"
 version = "1.2.1"
 dependencies = [
  "clap",
+ "console_error_panic_hook",
  "getrandom",
+ "js-sys",
+ "once_cell",
  "regex",
  "uuid7",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -213,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -231,12 +245,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -255,9 +269,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -271,9 +285,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "log"
@@ -341,7 +355,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -352,9 +366,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "regex"
@@ -391,7 +405,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd71575b08040a946d6b0850fd0d3c1d9e0d698ab9cc7da1c5cd8bea4f69a12f"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -516,35 +530,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -552,22 +553,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -604,6 +605,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,14 @@ crate-type = ["rlib", "cdylib"]
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 uuid7 = "1.7.0"
-wasm-bindgen = "=0.2.100"
+wasm-bindgen = "0.2.100"
+js-sys = "0.3"
+once_cell = "1.20"
+web-sys = { version = "0.3", features = ["Window", "Crypto"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.4.2", features = ["wasm_js"] }
+console_error_panic_hook = "0.1.7"
 
 [profile.release]
 strip = "debuginfo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,25 +5,29 @@ edition = "2024"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/daisuke-nagao/GuardGen"
+description = "GuardGen is a CLI tool for generating unique UUID v7 header guards for C/C++ files, ensuring conflict-free inclusion."
 
 [lib]
-crate-type = ["rlib", "cdylib"]
+name = "guardgen_lib"
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "guardgen"
 
 [dependencies]
-clap = { version = "4.6.0", features = ["derive"] }
-uuid7 = "1.7.0"
-wasm-bindgen = "0.2.100"
-js-sys = "0.3"
-once_cell = "1.20"
-web-sys = { version = "0.3", features = ["Window", "Crypto"] }
+clap = { version = "4.6.1", features = ["derive"] }
+uuid = { version = "1.23.1", features = ["rng-getrandom", "v4", "v7"] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.4.2", features = ["wasm_js"] }
-console_error_panic_hook = "0.1.7"
+js-sys = "0.3.95"
+wasm-bindgen = { version = "0.2.118" }
+uuid = { version = "1.23.1", features = ["rng-getrandom", "v4", "v7", "js"] }
 
 [profile.release]
 strip = "debuginfo"
 lto = true
+codegen-units = 1
 
 [dev-dependencies]
 regex = "1.12.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,16 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/daisuke-nagao/GuardGen"
 
+[lib]
+crate-type = ["rlib", "cdylib"]
+
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 uuid7 = "1.7.0"
+wasm-bindgen = "=0.2.100"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.4.2", features = ["wasm_js"] }
 
 [profile.release]
 strip = "debuginfo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ strip = "debuginfo"
 
 [dev-dependencies]
 regex = "1.12.3"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "guardgen"
 version = "1.2.1"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/daisuke-nagao/GuardGen"
@@ -23,6 +23,7 @@ console_error_panic_hook = "0.1.7"
 
 [profile.release]
 strip = "debuginfo"
+lto = true
 
 [dev-dependencies]
 regex = "1.12.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,11 @@ pub fn generate_guard_wasm(
     language: &str,
     line_ending: &str,
 ) -> Result<String, JsValue> {
+    // Install panic hook so Rust panic messages appear in browser devtools console.
+    // This statement is compiled only on wasm32 targets where the crate is available.
+    #[cfg(target_arch = "wasm32")]
+    console_error_panic_hook::set_once();
+
     // Preconditions: reject empty prefixes early because they produce malformed guard names.
     if prefix.trim().is_empty() {
         return Err(JsValue::from_str("prefix must not be empty"));
@@ -147,8 +152,78 @@ pub fn generate_guard(
     x: Language,
     line_ending: LineEnding,
 ) -> String {
-    // Generate a UUID and format it for use in the include guard.
-    let uuid = uuid7::uuid7().to_string().replace('-', "_").to_uppercase();
+    // Generate a UUID-like identifier for use in the include guard.
+    // Use `uuid7` on native targets. For `wasm32`, instantiate a `V7Generator`
+    // with a JS-backed `TimeSource` (Date.now()) and a `RandSource` that uses
+    // `getrandom` so we avoid calls to `std::time` which panic on wasm.
+    #[cfg(target_arch = "wasm32")]
+    mod wasm_uuid7 {
+        use js_sys::Date;
+        use once_cell::sync::Lazy;
+        use std::sync::Mutex;
+        use uuid7::generator::{RandSource, TimeSource};
+        use uuid7::V7Generator;
+
+        pub struct WasmTimeSource;
+        impl TimeSource for WasmTimeSource {
+            fn unix_ts_ms(&mut self) -> u64 {
+                // Date::now() returns milliseconds as f64; cast to u64.
+                Date::now() as u64
+            }
+        }
+
+        use web_sys::window;
+
+        pub struct GetRandomSource;
+        impl RandSource for GetRandomSource {
+            fn next_u32(&mut self) -> u32 {
+                let mut b = [0u8; 4];
+                let win = window().expect("no window");
+                let crypto = win.crypto().expect("no crypto available");
+                // Fill via get_random_values into a Uint8Array backed by our buffer
+                crypto
+                    .get_random_values_with_u8_array(&mut b)
+                    .expect("get_random_values failed");
+                u32::from_be_bytes(b)
+            }
+
+            fn next_u64(&mut self) -> u64 {
+                let mut b = [0u8; 8];
+                let win = window().expect("no window");
+                let crypto = win.crypto().expect("no crypto available");
+                crypto
+                    .get_random_values_with_u8_array(&mut b)
+                    .expect("get_random_values failed");
+                u64::from_be_bytes(b)
+            }
+        }
+
+        static GLOBAL_GEN: Lazy<Mutex<V7Generator<GetRandomSource, WasmTimeSource>>> =
+            Lazy::new(|| {
+                Mutex::new(V7Generator::with_rand_and_time_sources(
+                    GetRandomSource,
+                    WasmTimeSource,
+                ))
+            });
+
+        pub fn generate_uuid_string() -> String {
+            let mut g = GLOBAL_GEN.lock().unwrap();
+            g.generate().to_string()
+        }
+    }
+
+    let uuid = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            wasm_uuid7::generate_uuid_string()
+                .replace('-', "_")
+                .to_uppercase()
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            uuid7::uuid7().to_string().replace('-', "_").to_uppercase()
+        }
+    };
     let mut guard = vec![prefix, uuid];
 
     // Append suffix if provided.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Daisuke Nagao
 // SPDX-License-Identifier: MIT
 
-use clap::ValueEnum;
-
 /// Enum representing the target language.
 /// - `None`: No language-specific modifications.
 /// - `C`: Adds `extern "C"` for C compatibility.
 /// - `Cxx`: No additional modifications (C++ default behavior).
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Copy, Clone, Debug)]
 pub enum Language {
     None,
     C,
@@ -19,7 +17,7 @@ pub enum Language {
 /// - `None`: Uses system default.
 /// - `LF`: Uses Unix-style LF.
 /// - `CRLF`: Uses Windows-style CRLF.
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Copy, Clone, Debug)]
 pub enum LineEnding {
     None,
     LF,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,139 +1,32 @@
 // SPDX-FileCopyrightText: 2026 Daisuke Nagao
 // SPDX-License-Identifier: MIT
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen::prelude::*;
 
 /// Enum representing the target language.
 /// - `None`: No language-specific modifications.
 /// - `C`: Adds `extern "C"` for C compatibility.
 /// - `Cxx`: No additional modifications (C++ default behavior).
-#[derive(Copy, Clone, Debug)]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Language {
     None,
     C,
     Cxx,
 }
 
-impl Language {
-    /// Parses a JavaScript-friendly language specifier.
-    ///
-    /// Preconditions:
-    /// - `value` is expected to represent one of: `none`, `c`, or `cxx`.
-    ///
-    /// Postconditions:
-    /// - Returns `Ok(Language)` when the value is recognized.
-    /// - Returns `Err(String)` with a human-readable reason when invalid.
-    ///
-    /// Invariants:
-    /// - The mapping is case-insensitive.
-    fn parse_for_wasm(value: &str) -> Result<Self, String> {
-        let normalized = value.trim().to_ascii_lowercase();
-        let parsed = match normalized.as_str() {
-            // Branch: explicit no-op language mode.
-            "none" => Ok(Self::None),
-            // Branch: C compatibility mode inserts extern "C" block.
-            "c" => Ok(Self::C),
-            // Branch: C++ mode uses plain include guard output.
-            "cxx" | "cpp" | "c++" => Ok(Self::Cxx),
-            // Branch: unsupported keyword from JavaScript caller.
-            _ => Err(format!(
-                "invalid language '{}'; expected one of: none, c, cxx",
-                value
-            )),
-        };
-
-        parsed
-    }
-}
-
-#[allow(clippy::upper_case_acronyms)]
 /// Enum representing line-ending styles.
 /// - `None`: Uses system default.
 /// - `LF`: Uses Unix-style LF.
 /// - `CRLF`: Uses Windows-style CRLF.
-#[derive(Copy, Clone, Debug)]
+#[allow(clippy::upper_case_acronyms)]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum LineEnding {
     None,
     LF,
     CRLF,
-}
-
-impl LineEnding {
-    /// Parses a JavaScript-friendly line-ending specifier.
-    ///
-    /// Preconditions:
-    /// - `value` is expected to represent one of: `none`, `lf`, or `crlf`.
-    ///
-    /// Postconditions:
-    /// - Returns `Ok(LineEnding)` when the value is recognized.
-    /// - Returns `Err(String)` with a human-readable reason when invalid.
-    ///
-    /// Invariants:
-    /// - The mapping is case-insensitive.
-    fn parse_for_wasm(value: &str) -> Result<Self, String> {
-        let normalized = value.trim().to_ascii_lowercase();
-        let parsed = match normalized.as_str() {
-            // Branch: auto-detects line ending based on runtime target.
-            "none" | "auto" => Ok(Self::None),
-            // Branch: enforces LF newline style.
-            "lf" => Ok(Self::LF),
-            // Branch: enforces CRLF newline style.
-            "crlf" => Ok(Self::CRLF),
-            // Branch: unsupported keyword from JavaScript caller.
-            _ => Err(format!(
-                "invalid line ending '{}'; expected one of: none, lf, crlf",
-                value
-            )),
-        };
-
-        parsed
-    }
-}
-
-/// WebAssembly-exported wrapper for JavaScript/browser callers.
-///
-/// Preconditions:
-/// - `prefix` should be a non-empty identifier-like string.
-/// - `language` should be one of: `none`, `c`, or `cxx`.
-/// - `line_ending` should be one of: `none`, `lf`, or `crlf`.
-///
-/// Postconditions:
-/// - Returns the generated include guard text on success.
-/// - Returns a JavaScript exception (`JsValue`) if inputs are invalid.
-///
-/// Invariants:
-/// - Delegates guard construction to `generate_guard` so output format remains consistent.
-#[wasm_bindgen]
-pub fn generate_guard_wasm(
-    prefix: &str,
-    suffix: Option<String>,
-    language: &str,
-    line_ending: &str,
-) -> Result<String, JsValue> {
-    // Install panic hook so Rust panic messages appear in browser devtools console.
-    // This statement is compiled only on wasm32 targets where the crate is available.
-    #[cfg(target_arch = "wasm32")]
-    console_error_panic_hook::set_once();
-
-    // Preconditions: reject empty prefixes early because they produce malformed guard names.
-    if prefix.trim().is_empty() {
-        return Err(JsValue::from_str("prefix must not be empty"));
-    }
-
-    let language_value = Language::parse_for_wasm(language)
-        .map_err(|err| JsValue::from_str(format!("language error: {}", err).as_str()))?;
-    let line_ending_value = LineEnding::parse_for_wasm(line_ending)
-        .map_err(|err| JsValue::from_str(format!("line ending error: {}", err).as_str()))?;
-
-    // Branch: suffix is optional and passed through unchanged to core logic.
-    let generated = generate_guard(
-        prefix.to_string(),
-        suffix,
-        language_value,
-        line_ending_value,
-    );
-
-    Ok(generated)
 }
 
 /// Generates an include guard string with optional language-specific modifications.
@@ -146,84 +39,15 @@ pub fn generate_guard_wasm(
 ///
 /// # Returns
 /// A formatted include guard string.
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen)]
 pub fn generate_guard(
     prefix: String,
     suffix: Option<String>,
     x: Language,
     line_ending: LineEnding,
 ) -> String {
-    // Generate a UUID-like identifier for use in the include guard.
-    // Use `uuid7` on native targets. For `wasm32`, instantiate a `V7Generator`
-    // with a JS-backed `TimeSource` (Date.now()) and a `RandSource` that uses
-    // `getrandom` so we avoid calls to `std::time` which panic on wasm.
-    #[cfg(target_arch = "wasm32")]
-    mod wasm_uuid7 {
-        use js_sys::Date;
-        use once_cell::sync::Lazy;
-        use std::sync::Mutex;
-        use uuid7::generator::{RandSource, TimeSource};
-        use uuid7::V7Generator;
-
-        pub struct WasmTimeSource;
-        impl TimeSource for WasmTimeSource {
-            fn unix_ts_ms(&mut self) -> u64 {
-                // Date::now() returns milliseconds as f64; cast to u64.
-                Date::now() as u64
-            }
-        }
-
-        use web_sys::window;
-
-        pub struct GetRandomSource;
-        impl RandSource for GetRandomSource {
-            fn next_u32(&mut self) -> u32 {
-                let mut b = [0u8; 4];
-                let win = window().expect("no window");
-                let crypto = win.crypto().expect("no crypto available");
-                // Fill via get_random_values into a Uint8Array backed by our buffer
-                crypto
-                    .get_random_values_with_u8_array(&mut b)
-                    .expect("get_random_values failed");
-                u32::from_be_bytes(b)
-            }
-
-            fn next_u64(&mut self) -> u64 {
-                let mut b = [0u8; 8];
-                let win = window().expect("no window");
-                let crypto = win.crypto().expect("no crypto available");
-                crypto
-                    .get_random_values_with_u8_array(&mut b)
-                    .expect("get_random_values failed");
-                u64::from_be_bytes(b)
-            }
-        }
-
-        static GLOBAL_GEN: Lazy<Mutex<V7Generator<GetRandomSource, WasmTimeSource>>> =
-            Lazy::new(|| {
-                Mutex::new(V7Generator::with_rand_and_time_sources(
-                    GetRandomSource,
-                    WasmTimeSource,
-                ))
-            });
-
-        pub fn generate_uuid_string() -> String {
-            let mut g = GLOBAL_GEN.lock().unwrap();
-            g.generate().to_string()
-        }
-    }
-
-    let uuid = {
-        #[cfg(target_arch = "wasm32")]
-        {
-            wasm_uuid7::generate_uuid_string()
-                .replace('-', "_")
-                .to_uppercase()
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            uuid7::uuid7().to_string().replace('-', "_").to_uppercase()
-        }
-    };
+    // Generate a UUID and format it for use in the include guard.
+    let uuid = generate().to_string().replace('-', "_").to_uppercase();
     let mut guard = vec![prefix, uuid];
 
     // Append suffix if provided.
@@ -277,6 +101,35 @@ pub fn generate_guard(
 
     // Join all lines with the appropriate newline character.
     text.join(&newline)
+}
+
+fn unix_time() -> (u64, u32) {
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        // `js_sys::Date::now()` returns milliseconds since the epoch as an `f64`.
+        // Convert to integer milliseconds, then split into seconds and nanoseconds.
+        let unix_ms = js_sys::Date::now().floor() as u64;
+        let seconds = unix_ms / 1000u64;
+        let nanos = ((unix_ms % 1000) as u32) * 1_000_000u32;
+        (seconds, nanos)
+    }
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards");
+        let seconds = now.as_secs();
+        // `subsec_millis()` returns the subsecond part in milliseconds; convert to nanoseconds.
+        let nanos = now.subsec_millis() * 1_000_000;
+        (seconds, nanos)
+    }
+}
+
+fn generate() -> uuid::Uuid {
+    let (seconds, millis) = unix_time();
+    let ts = uuid::Timestamp::from_unix(uuid::NoContext, seconds, millis);
+
+    uuid::Uuid::new_v7(ts)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Daisuke Nagao
 // SPDX-License-Identifier: MIT
 
+use wasm_bindgen::prelude::*;
+
 /// Enum representing the target language.
 /// - `None`: No language-specific modifications.
 /// - `C`: Adds `extern "C"` for C compatibility.
@@ -10,6 +12,38 @@ pub enum Language {
     None,
     C,
     Cxx,
+}
+
+impl Language {
+    /// Parses a JavaScript-friendly language specifier.
+    ///
+    /// Preconditions:
+    /// - `value` is expected to represent one of: `none`, `c`, or `cxx`.
+    ///
+    /// Postconditions:
+    /// - Returns `Ok(Language)` when the value is recognized.
+    /// - Returns `Err(String)` with a human-readable reason when invalid.
+    ///
+    /// Invariants:
+    /// - The mapping is case-insensitive.
+    fn parse_for_wasm(value: &str) -> Result<Self, String> {
+        let normalized = value.trim().to_ascii_lowercase();
+        let parsed = match normalized.as_str() {
+            // Branch: explicit no-op language mode.
+            "none" => Ok(Self::None),
+            // Branch: C compatibility mode inserts extern "C" block.
+            "c" => Ok(Self::C),
+            // Branch: C++ mode uses plain include guard output.
+            "cxx" | "cpp" | "c++" => Ok(Self::Cxx),
+            // Branch: unsupported keyword from JavaScript caller.
+            _ => Err(format!(
+                "invalid language '{}'; expected one of: none, c, cxx",
+                value
+            )),
+        };
+
+        parsed
+    }
 }
 
 #[allow(clippy::upper_case_acronyms)]
@@ -22,6 +56,79 @@ pub enum LineEnding {
     None,
     LF,
     CRLF,
+}
+
+impl LineEnding {
+    /// Parses a JavaScript-friendly line-ending specifier.
+    ///
+    /// Preconditions:
+    /// - `value` is expected to represent one of: `none`, `lf`, or `crlf`.
+    ///
+    /// Postconditions:
+    /// - Returns `Ok(LineEnding)` when the value is recognized.
+    /// - Returns `Err(String)` with a human-readable reason when invalid.
+    ///
+    /// Invariants:
+    /// - The mapping is case-insensitive.
+    fn parse_for_wasm(value: &str) -> Result<Self, String> {
+        let normalized = value.trim().to_ascii_lowercase();
+        let parsed = match normalized.as_str() {
+            // Branch: auto-detects line ending based on runtime target.
+            "none" | "auto" => Ok(Self::None),
+            // Branch: enforces LF newline style.
+            "lf" => Ok(Self::LF),
+            // Branch: enforces CRLF newline style.
+            "crlf" => Ok(Self::CRLF),
+            // Branch: unsupported keyword from JavaScript caller.
+            _ => Err(format!(
+                "invalid line ending '{}'; expected one of: none, lf, crlf",
+                value
+            )),
+        };
+
+        parsed
+    }
+}
+
+/// WebAssembly-exported wrapper for JavaScript/browser callers.
+///
+/// Preconditions:
+/// - `prefix` should be a non-empty identifier-like string.
+/// - `language` should be one of: `none`, `c`, or `cxx`.
+/// - `line_ending` should be one of: `none`, `lf`, or `crlf`.
+///
+/// Postconditions:
+/// - Returns the generated include guard text on success.
+/// - Returns a JavaScript exception (`JsValue`) if inputs are invalid.
+///
+/// Invariants:
+/// - Delegates guard construction to `generate_guard` so output format remains consistent.
+#[wasm_bindgen]
+pub fn generate_guard_wasm(
+    prefix: &str,
+    suffix: Option<String>,
+    language: &str,
+    line_ending: &str,
+) -> Result<String, JsValue> {
+    // Preconditions: reject empty prefixes early because they produce malformed guard names.
+    if prefix.trim().is_empty() {
+        return Err(JsValue::from_str("prefix must not be empty"));
+    }
+
+    let language_value = Language::parse_for_wasm(language)
+        .map_err(|err| JsValue::from_str(format!("language error: {}", err).as_str()))?;
+    let line_ending_value = LineEnding::parse_for_wasm(line_ending)
+        .map_err(|err| JsValue::from_str(format!("line ending error: {}", err).as_str()))?;
+
+    // Branch: suffix is optional and passed through unchanged to core logic.
+    let generated = generate_guard(
+        prefix.to_string(),
+        suffix,
+        language_value,
+        line_ending_value,
+    );
+
+    Ok(generated)
 }
 
 /// Generates an include guard string with optional language-specific modifications.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 Daisuke Nagao
+// SPDX-License-Identifier: MIT
+
+use clap::ValueEnum;
+
+/// Enum representing the target language.
+/// - `None`: No language-specific modifications.
+/// - `C`: Adds `extern "C"` for C compatibility.
+/// - `Cxx`: No additional modifications (C++ default behavior).
+#[derive(Clone, Debug, ValueEnum)]
+pub enum Language {
+    None,
+    C,
+    Cxx,
+}
+
+#[allow(clippy::upper_case_acronyms)]
+/// Enum representing line-ending styles.
+/// - `None`: Uses system default.
+/// - `LF`: Uses Unix-style LF.
+/// - `CRLF`: Uses Windows-style CRLF.
+#[derive(Clone, Debug, ValueEnum)]
+pub enum LineEnding {
+    None,
+    LF,
+    CRLF,
+}
+
+/// Generates an include guard string with optional language-specific modifications.
+///
+/// # Arguments
+/// * `prefix` - A prefix string for the guard name.
+/// * `suffix` - An optional suffix for the guard name.
+/// * `x` - The target language (C or C++).
+/// * `line_ending` - The line-ending format.
+///
+/// # Returns
+/// A formatted include guard string.
+pub fn generate_guard(
+    prefix: String,
+    suffix: Option<String>,
+    x: Language,
+    line_ending: LineEnding,
+) -> String {
+    // Generate a UUID and format it for use in the include guard.
+    let uuid = uuid7::uuid7().to_string().replace('-', "_").to_uppercase();
+    let mut guard = vec![prefix, uuid];
+
+    // Append suffix if provided.
+    if let Some(suffix) = suffix {
+        guard.push(suffix);
+    }
+
+    // Join guard components with underscores.
+    let guard = guard.join("_");
+
+    // Define standard include guard macros.
+    let ifndef = format!("#ifndef {}", guard);
+    let define = format!("#define {}", guard);
+    let endif = format!("#endif /* {} */", guard);
+
+    let mut text = vec![ifndef, define];
+
+    // If the target language is C, add `extern "C"` blocks for compatibility.
+    if let Language::C = x {
+        let extern_c: Vec<String> = vec![
+            "".to_string(), // blank line
+            "#ifdef __cplusplus".to_string(),
+            "extern \"C\" {".to_string(),
+            "#endif /* __cplusplus */".to_string(),
+            "".to_string(), // blank line
+            "#ifdef __cplusplus".to_string(),
+            "} /* extern \"C\" */".to_string(),
+            "#endif /* __cplusplus */".to_string(),
+            "".to_string(), // blank line
+        ];
+        text.extend(extern_c);
+    }
+
+    // Append closing `#endif` statement.
+    text.push(endif);
+    text.push("".to_string());
+
+    // Determine the newline character based on the specified line-ending format.
+    let newline = match line_ending {
+        LineEnding::LF => "\n",
+        LineEnding::CRLF => "\r\n",
+        LineEnding::None => {
+            if cfg!(target_os = "windows") {
+                "\r\n"
+            } else {
+                "\n"
+            }
+        }
+    }
+    .to_string();
+
+    // Join all lines with the appropriate newline character.
+    text.join(&newline)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    fn extract_uuids(text: &str) -> Vec<String> {
+        let re =
+            Regex::new(r"[0-9A-F]{8}_[0-9A-F]{4}_[0-9A-F]{4}_[0-9A-F]{4}_[0-9A-F]{12}").unwrap();
+
+        re.find_iter(text)
+            .map(|mat| mat.as_str().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn test_generate_guard_default() {
+        let result = generate_guard("TEST".to_string(), None, Language::None, LineEnding::LF);
+
+        let uuids = extract_uuids(result.as_str());
+
+        assert!(uuids.len() == 3);
+        assert!(uuids[0] == uuids[1]);
+        assert!(uuids[1] == uuids[2]);
+
+        let uuid = &uuids[0];
+        assert!(result.contains(format!("#ifndef TEST_{}", uuid).as_str()));
+        assert!(result.contains(format!("#define TEST_{}", uuid).as_str()));
+        assert!(result.contains(format!("#endif /* TEST_{} */", uuid).as_str()));
+    }
+
+    #[test]
+    fn test_generate_guard_with_suffix() {
+        let result = generate_guard(
+            "TEST".to_string(),
+            Some("SUFFIX".to_string()),
+            Language::Cxx,
+            LineEnding::LF,
+        );
+
+        let uuids = extract_uuids(result.as_str());
+
+        assert!(uuids.len() == 3);
+        assert!(uuids[0] == uuids[1]);
+        assert!(uuids[1] == uuids[2]);
+
+        let uuid = &uuids[0];
+        assert!(result.contains(format!("#ifndef TEST_{}_SUFFIX", uuid).as_str()));
+        assert!(result.contains(format!("#define TEST_{}_SUFFIX", uuid).as_str()));
+        assert!(result.contains(format!("#endif /* TEST_{}_SUFFIX */", uuid).as_str()));
+    }
+
+    #[test]
+    fn test_generate_guard_with_c_compatibility() {
+        let result = generate_guard("TEST".to_string(), None, Language::C, LineEnding::LF);
+
+        let uuids = extract_uuids(result.as_str());
+
+        assert!(uuids.len() == 3);
+        assert!(uuids[0] == uuids[1]);
+        assert!(uuids[1] == uuids[2]);
+
+        let uuid = &uuids[0];
+        assert!(result.contains(format!("#ifndef TEST_{}", uuid).as_str()));
+        assert!(result.contains(format!("#define TEST_{}", uuid).as_str()));
+        assert!(result.contains(format!("#endif /* TEST_{} */", uuid).as_str()));
+
+        assert!(result.contains("#ifdef __cplusplus"));
+        assert!(result.contains("extern \"C\" {"));
+        assert!(result.contains("} /* extern \"C\" */"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,53 @@
 // SPDX-FileCopyrightText: 2025 Daisuke Nagao
 // SPDX-License-Identifier: MIT
 
-use clap::Parser;
-use clap::ValueEnum;
+use clap::{Parser, ValueEnum};
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
+
+/// Enum representing the target language.
+/// - `None`: No language-specific modifications.
+/// - `C`: Adds `extern "C"` for C compatibility.
+/// - `Cxx`: No additional modifications (C++ default behavior).
+#[derive(Clone, Debug, ValueEnum)]
+enum Language {
+    None,
+    C,
+    Cxx,
+}
+
+impl From<Language> for guardgen_lib::Language {
+    fn from(val: Language) -> Self {
+        match val {
+            Language::None => guardgen_lib::Language::None,
+            Language::C => guardgen_lib::Language::C,
+            Language::Cxx => guardgen_lib::Language::Cxx,
+        }
+    }
+}
+
+#[allow(clippy::upper_case_acronyms)]
+/// Enum representing line-ending styles.
+/// - `None`: Uses system default.
+/// - `LF`: Uses Unix-style LF.
+/// - `CRLF`: Uses Windows-style CRLF.
+#[derive(Clone, Debug, ValueEnum)]
+enum LineEnding {
+    None,
+    LF,
+    CRLF,
+}
+
+impl From<LineEnding> for guardgen_lib::LineEnding {
+    fn from(val: LineEnding) -> Self {
+        match val {
+            LineEnding::None => guardgen_lib::LineEnding::None,
+            LineEnding::LF => guardgen_lib::LineEnding::LF,
+            LineEnding::CRLF => guardgen_lib::LineEnding::CRLF,
+        }
+    }
+}
 
 /// Command-line argument parser using `clap`.
 #[derive(Parser, Debug)]
@@ -51,23 +93,23 @@ struct Args {
     #[arg(
         short,
         value_enum,
-        default_value_t = LanguageArg::None,
+        default_value_t = Language::None,
         ignore_case = true,
         help = "Specify the language for compatibility adjustments. \
                 Options: none (default), c (adds extern \"C\" blocks), cxx (no additional modification)."
     )]
-    x: LanguageArg,
+    x: Language,
 
     /// Line-ending style (LF/CRLF)
     #[arg(
         long = "line-ending",
         value_enum,
-        default_value_t = LineEndingArg::None,
+        default_value_t = LineEnding::None,
         ignore_case = true,
         help = "Specify the line-ending style. \
                 Options: none (auto-detect), lf (Unix-style LF), crlf (Windows-style CRLF)."
     )]
-    line_ending: LineEndingArg,
+    line_ending: LineEnding,
 }
 
 /// Main function that parses arguments and generates the include guard.
@@ -76,8 +118,7 @@ fn main() {
     let args = Args::parse();
 
     // Generate the include guard based on user input.
-    // Convert CLI wrapper enums into library enums to keep the library clap-agnostic.
-    let guard = guardgen::generate_guard(
+    let guard = guardgen_lib::generate_guard(
         args.prefix,
         args.suffix,
         args.x.into(),
@@ -128,43 +169,5 @@ fn main() {
     } else {
         // Print the include guard to stdout if no output file is specified.
         println!("{}", guard);
-    }
-}
-
-// Wrapper enums for CLI integration.
-// These are defined in the binary crate so we can derive `clap::ValueEnum`
-// without violating Rust's orphan rules. They convert into the library
-// enums (`guardgen::Language` and `guardgen::LineEnding`).
-#[derive(ValueEnum, Clone, Copy, Debug)]
-enum LanguageArg {
-    None,
-    C,
-    Cxx,
-}
-
-impl From<LanguageArg> for guardgen::Language {
-    fn from(v: LanguageArg) -> guardgen::Language {
-        match v {
-            LanguageArg::None => guardgen::Language::None,
-            LanguageArg::C => guardgen::Language::C,
-            LanguageArg::Cxx => guardgen::Language::Cxx,
-        }
-    }
-}
-
-#[derive(ValueEnum, Clone, Copy, Debug)]
-enum LineEndingArg {
-    None,
-    LF,
-    CRLF,
-}
-
-impl From<LineEndingArg> for guardgen::LineEnding {
-    fn from(v: LineEndingArg) -> guardgen::LineEnding {
-        match v {
-            LineEndingArg::None => guardgen::LineEnding::None,
-            LineEndingArg::LF => guardgen::LineEnding::LF,
-            LineEndingArg::CRLF => guardgen::LineEnding::CRLF,
-        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,10 @@
 // SPDX-FileCopyrightText: 2025 Daisuke Nagao
 // SPDX-License-Identifier: MIT
 
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
-
-/// Enum representing the target language.
-/// - `None`: No language-specific modifications.
-/// - `C`: Adds `extern "C"` for C compatibility.
-/// - `Cxx`: No additional modifications (C++ default behavior).
-#[derive(Clone, Debug, ValueEnum)]
-enum Language {
-    None,
-    C,
-    Cxx,
-}
-
-#[allow(clippy::upper_case_acronyms)]
-/// Enum representing line-ending styles.
-/// - `None`: Uses system default.
-/// - `LF`: Uses Unix-style LF.
-/// - `CRLF`: Uses Windows-style CRLF.
-#[derive(Clone, Debug, ValueEnum)]
-enum LineEnding {
-    None,
-    LF,
-    CRLF,
-}
 
 /// Command-line argument parser using `clap`.
 #[derive(Parser, Debug)]
@@ -73,96 +50,23 @@ struct Args {
     #[arg(
         short,
         value_enum,
-        default_value_t = Language::None,
+        default_value_t = guardgen::Language::None,
         ignore_case = true,
         help = "Specify the language for compatibility adjustments. \
                 Options: none (default), c (adds extern \"C\" blocks), cxx (no additional modification)."
     )]
-    x: Language,
+    x: guardgen::Language,
 
     /// Line-ending style (LF/CRLF)
     #[arg(
         long = "line-ending",
         value_enum,
-        default_value_t = LineEnding::None,
+        default_value_t = guardgen::LineEnding::None,
         ignore_case = true,
         help = "Specify the line-ending style. \
                 Options: none (auto-detect), lf (Unix-style LF), crlf (Windows-style CRLF)."
     )]
-    line_ending: LineEnding,
-}
-
-/// Generates an include guard string with optional language-specific modifications.
-///
-/// # Arguments
-/// * `prefix` - A prefix string for the guard name.
-/// * `suffix` - An optional suffix for the guard name.
-/// * `x` - The target language (C or C++).
-/// * `line_ending` - The line-ending format.
-///
-/// # Returns
-/// A formatted include guard string.
-fn generate_guard(
-    prefix: String,
-    suffix: Option<String>,
-    x: Language,
-    line_ending: LineEnding,
-) -> String {
-    // Generate a UUID and format it for use in the include guard.
-    let uuid = uuid7::uuid7().to_string().replace('-', "_").to_uppercase();
-    let mut guard = vec![prefix, uuid];
-
-    // Append suffix if provided.
-    if let Some(suffix) = suffix {
-        guard.push(suffix);
-    }
-
-    // Join guard components with underscores.
-    let guard = guard.join("_");
-
-    // Define standard include guard macros.
-    let ifndef = format!("#ifndef {}", guard);
-    let define = format!("#define {}", guard);
-    let endif = format!("#endif /* {} */", guard);
-
-    let mut text = vec![ifndef, define];
-
-    // If the target language is C, add `extern "C"` blocks for compatibility.
-    if let Language::C = x {
-        let extern_c: Vec<String> = vec![
-            "".to_string(), // blank line
-            "#ifdef __cplusplus".to_string(),
-            "extern \"C\" {".to_string(),
-            "#endif /* __cplusplus */".to_string(),
-            "".to_string(), // blank line
-            "#ifdef __cplusplus".to_string(),
-            "} /* extern \"C\" */".to_string(),
-            "#endif /* __cplusplus */".to_string(),
-            "".to_string(), // blank line
-        ];
-        text.extend(extern_c);
-    }
-
-    // Append closing `#endif` statement.
-    text.push(endif);
-    text.push("".to_string());
-
-    // Determine the newline character based on the specified line-ending format.
-    let newline = match line_ending {
-        LineEnding::LF => "\n",
-        LineEnding::CRLF => "\r\n",
-        LineEnding::None => {
-            if cfg!(target_os = "windows") {
-                "\r\n"
-            } else {
-                "\n"
-            }
-        }
-    }
-    .to_string();
-
-    // Join all lines with the appropriate newline character.
-    text.join(&newline)
+    line_ending: guardgen::LineEnding,
 }
 
 /// Main function that parses arguments and generates the include guard.
@@ -171,7 +75,7 @@ fn main() {
     let args = Args::parse();
 
     // Generate the include guard based on user input.
-    let guard = generate_guard(args.prefix, args.suffix, args.x, args.line_ending);
+    let guard = guardgen::generate_guard(args.prefix, args.suffix, args.x, args.line_ending);
 
     if let Some(file_path) = &args.filename {
         // Check if the file already exists and prevent overwriting unless explicitly allowed.
@@ -217,77 +121,5 @@ fn main() {
     } else {
         // Print the include guard to stdout if no output file is specified.
         println!("{}", guard);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use regex::Regex;
-
-    fn extract_uuids(text: &str) -> Vec<String> {
-        let re =
-            Regex::new(r"[0-9A-F]{8}_[0-9A-F]{4}_[0-9A-F]{4}_[0-9A-F]{4}_[0-9A-F]{12}").unwrap();
-
-        re.find_iter(text)
-            .map(|mat| mat.as_str().to_string())
-            .collect()
-    }
-
-    #[test]
-    fn test_generate_guard_default() {
-        let result = generate_guard("TEST".to_string(), None, Language::None, LineEnding::LF);
-
-        let uuids = extract_uuids(result.as_str());
-
-        assert!(uuids.len() == 3);
-        assert!(uuids[0] == uuids[1]);
-        assert!(uuids[1] == uuids[2]);
-
-        let uuid = &uuids[0];
-        assert!(result.contains(format!("#ifndef TEST_{}", uuid).as_str()));
-        assert!(result.contains(format!("#define TEST_{}", uuid).as_str()));
-        assert!(result.contains(format!("#endif /* TEST_{} */", uuid).as_str()));
-    }
-
-    #[test]
-    fn test_generate_guard_with_suffix() {
-        let result = generate_guard(
-            "TEST".to_string(),
-            Some("SUFFIX".to_string()),
-            Language::Cxx,
-            LineEnding::LF,
-        );
-
-        let uuids = extract_uuids(result.as_str());
-
-        assert!(uuids.len() == 3);
-        assert!(uuids[0] == uuids[1]);
-        assert!(uuids[1] == uuids[2]);
-
-        let uuid = &uuids[0];
-        assert!(result.contains(format!("#ifndef TEST_{}_SUFFIX", uuid).as_str()));
-        assert!(result.contains(format!("#define TEST_{}_SUFFIX", uuid).as_str()));
-        assert!(result.contains(format!("#endif /* TEST_{}_SUFFIX */", uuid).as_str()));
-    }
-
-    #[test]
-    fn test_generate_guard_with_c_compatibility() {
-        let result = generate_guard("TEST".to_string(), None, Language::C, LineEnding::LF);
-
-        let uuids = extract_uuids(result.as_str());
-
-        assert!(uuids.len() == 3);
-        assert!(uuids[0] == uuids[1]);
-        assert!(uuids[1] == uuids[2]);
-
-        let uuid = &uuids[0];
-        assert!(result.contains(format!("#ifndef TEST_{}", uuid).as_str()));
-        assert!(result.contains(format!("#define TEST_{}", uuid).as_str()));
-        assert!(result.contains(format!("#endif /* TEST_{} */", uuid).as_str()));
-
-        assert!(result.contains("#ifdef __cplusplus"));
-        assert!(result.contains("extern \"C\" {"));
-        assert!(result.contains("} /* extern \"C\" */"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use clap::Parser;
+use clap::ValueEnum;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -50,23 +51,23 @@ struct Args {
     #[arg(
         short,
         value_enum,
-        default_value_t = guardgen::Language::None,
+        default_value_t = LanguageArg::None,
         ignore_case = true,
         help = "Specify the language for compatibility adjustments. \
                 Options: none (default), c (adds extern \"C\" blocks), cxx (no additional modification)."
     )]
-    x: guardgen::Language,
+    x: LanguageArg,
 
     /// Line-ending style (LF/CRLF)
     #[arg(
         long = "line-ending",
         value_enum,
-        default_value_t = guardgen::LineEnding::None,
+        default_value_t = LineEndingArg::None,
         ignore_case = true,
         help = "Specify the line-ending style. \
                 Options: none (auto-detect), lf (Unix-style LF), crlf (Windows-style CRLF)."
     )]
-    line_ending: guardgen::LineEnding,
+    line_ending: LineEndingArg,
 }
 
 /// Main function that parses arguments and generates the include guard.
@@ -75,7 +76,13 @@ fn main() {
     let args = Args::parse();
 
     // Generate the include guard based on user input.
-    let guard = guardgen::generate_guard(args.prefix, args.suffix, args.x, args.line_ending);
+    // Convert CLI wrapper enums into library enums to keep the library clap-agnostic.
+    let guard = guardgen::generate_guard(
+        args.prefix,
+        args.suffix,
+        args.x.into(),
+        args.line_ending.into(),
+    );
 
     if let Some(file_path) = &args.filename {
         // Check if the file already exists and prevent overwriting unless explicitly allowed.
@@ -121,5 +128,43 @@ fn main() {
     } else {
         // Print the include guard to stdout if no output file is specified.
         println!("{}", guard);
+    }
+}
+
+// Wrapper enums for CLI integration.
+// These are defined in the binary crate so we can derive `clap::ValueEnum`
+// without violating Rust's orphan rules. They convert into the library
+// enums (`guardgen::Language` and `guardgen::LineEnding`).
+#[derive(ValueEnum, Clone, Copy, Debug)]
+enum LanguageArg {
+    None,
+    C,
+    Cxx,
+}
+
+impl From<LanguageArg> for guardgen::Language {
+    fn from(v: LanguageArg) -> guardgen::Language {
+        match v {
+            LanguageArg::None => guardgen::Language::None,
+            LanguageArg::C => guardgen::Language::C,
+            LanguageArg::Cxx => guardgen::Language::Cxx,
+        }
+    }
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug)]
+enum LineEndingArg {
+    None,
+    LF,
+    CRLF,
+}
+
+impl From<LineEndingArg> for guardgen::LineEnding {
+    fn from(v: LineEndingArg) -> guardgen::LineEnding {
+        match v {
+            LineEndingArg::None => guardgen::LineEnding::None,
+            LineEndingArg::LF => guardgen::LineEnding::LF,
+            LineEndingArg::CRLF => guardgen::LineEnding::CRLF,
+        }
     }
 }


### PR DESCRIPTION

**Description**
- **Summary**: Add WebAssembly support via `wasm-bindgen`, expose the library as `guardgen_lib` (cdylib + rlib), upgrade to Rust 2024 edition, and migrate UUID generation to UUID v7 using the `uuid` crate. Also update dependencies, enable release optimizations, and add a pre-commit config.

- **Key changes**:
  - **WASM**: Expose `Language`, `LineEnding`, and `generate_guard` to WASM with `#[wasm_bindgen]` on wasm targets; add `js-sys` and `wasm-bindgen`; implement wasm-safe timestamp via `js_sys::Date::now()`.
  - **UUID v7**: Replace previous UUID generation with `uuid::Uuid::new_v7(...)` via a new `generate()` helper and `unix_time()` abstraction (works on native and wasm).
  - **Crate & build**: Rename library crate to `guardgen_lib`, set `crate-type = ["cdylib","rlib"]`, bump edition to 2024, and enable `lto = true` + `codegen-units = 1` for release.
  - **CLI**: Update `main` to use `guardgen_lib` and implement `From` conversions for enums.
  - **Tooling**: Add .pre-commit-config.yaml and update Cargo.lock / dependencies.

- **Compatibility & migration notes**:
  - **Breaking**: The library crate name changed to `guardgen_lib` — update downstream imports/usages accordingly.
  - **Toolchain**: Requires a Rust toolchain that supports the 2024 edition.
  - **WASM build**: Install the `wasm32-unknown-unknown` target and use your preferred wasm packaging (`wasm-pack` / `wasm-bindgen`).
