### PR TITLE
Add GitHub Actions workflow for Rust WASM build and testing

### DIFF
--- a/.github/workflows/rust-ci-wasm.yml
+++ b/.github/workflows/rust-ci-wasm.yml
@@ -40,6 +40,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-build-
 
+      - name: Install Rust toolchain
+        run: rustup target add wasm32-unknown-unknown
+
       - name: Setup `wasmtime`
         uses: bytecodealliance/actions/wasmtime/setup@v1
 

--- a/.github/workflows/rust-ci-wasm.yml
+++ b/.github/workflows/rust-ci-wasm.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo build --verbose --target wasm32-wasip2
 
       - name: Run unit tests
-        run: cargo test --verbose --target wasm32-wasip2 -c target.wasm32-wasip2.runner=wasmtime
+        run: cargo test --verbose --target wasm32-wasip2 --config target.wasm32-wasip2.runner=wasmtime
 
       - name: Check for warnings
         run: cargo check --all-targets --all-features --verbose --target wasm32-wasip2

--- a/.github/workflows/rust-ci-wasm.yml
+++ b/.github/workflows/rust-ci-wasm.yml
@@ -1,0 +1,53 @@
+name: Rust Build and Test Wasm
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    name: Build and Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Cargo build
+        uses: actions/cache@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-
+
+      - name: Setup `wasmtime`
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+
+      - name: Build the project
+        run: cargo build --verbose --target wasm32-wasip2
+
+      - name: Run unit tests
+        run: cargo test --verbose --target wasm32-wasip2 -c target.wasm32-wasip2.runner=wasmtime
+
+      - name: Check for warnings
+        run: cargo check --all-targets --all-features --verbose --target wasm32-wasip2

--- a/.github/workflows/rust-ci-wasm.yml
+++ b/.github/workflows/rust-ci-wasm.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo build --verbose --target wasm32-wasip2
 
       - name: Run unit tests
-        run: cargo test --verbose --target wasm32-wasip2 --config target.wasm32-wasip2.runner="wasmtime"
+        run: cargo test --verbose --target wasm32-wasip2 --config 'target.wasm32-wasip2.runner="wasmtime"'
 
       - name: Check for warnings
         run: cargo check --all-targets --all-features --verbose --target wasm32-wasip2

--- a/.github/workflows/rust-ci-wasm.yml
+++ b/.github/workflows/rust-ci-wasm.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo build --verbose --target wasm32-wasip2
 
       - name: Run unit tests
-        run: cargo test --verbose --target wasm32-wasip2 --config target.wasm32-wasip2.runner=wasmtime
+        run: cargo test --verbose --target wasm32-wasip2 --config target.wasm32-wasip2.runner="wasmtime"
 
       - name: Check for warnings
         run: cargo check --all-targets --all-features --verbose --target wasm32-wasip2

--- a/.github/workflows/rust-ci-wasm.yml
+++ b/.github/workflows/rust-ci-wasm.yml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-cargo-build-
 
       - name: Install Rust toolchain
-        run: rustup target add wasm32-unknown-unknown
+        run: rustup target add wasm32-wasip2
 
       - name: Setup `wasmtime`
         uses: bytecodealliance/actions/wasmtime/setup@v1


### PR DESCRIPTION
- Create a new workflow file for building and testing Rust projects targeting WASM.
- Configure the workflow to trigger on pushes and pull requests to the main branch.
- Set up a matrix for different Ubuntu environments.
- Include steps for checking out the repository, caching Cargo registry and build, setting up `wasmtime`, building the project, running unit tests, and checking for warnings.