### PR TITLE
Refactor include-guard API to `IncludeGuardGenerator` struct and add UUID v7/v4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -92,9 +92,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cast"
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -268,7 +268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -287,9 +287,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -605,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -651,18 +651,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
 dependencies = [
  "async-trait",
  "cast",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
 
 [[package]]
 name = "wasm-encoder"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,9 @@ pub enum UuidKind {
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen)]
 pub struct IncludeGuardGenerator {
     // Private context used for UUID v7 generation to avoid collisions on rapid calls.
-    // Stored as (last_seconds, last_nanos, counter) to provide a small monotonic
-    // context without depending on internal uuid crate types.
-    v7_context: Option<(u64, u32, u32)>,
+    // Store the official `ContextV7` from the `uuid` crate so we can rely on its
+    // reseeding/monotonic behaviour instead of rolling our own counter logic.
+    v7_context: Option<uuid::ContextV7>,
 }
 
 impl IncludeGuardGenerator {
@@ -77,7 +77,7 @@ impl IncludeGuardGenerator {
     /// same context while varying parameters.
     pub fn new() -> Self {
         IncludeGuardGenerator {
-            v7_context: Some((0u64, 0u32, 0u32)),
+            v7_context: Some(uuid::ContextV7::new()),
         }
     }
 
@@ -101,32 +101,16 @@ impl IncludeGuardGenerator {
         let uuid_string = match uuid_kind {
             UuidKind::V4 => uuid::Uuid::new_v4().to_string(),
             UuidKind::V7 => {
-                // Use the existing `unix_time` helper to get seconds and subsecond
-                // component. Maintain a tiny local context (last timestamp + counter)
-                // to avoid collisions when multiple calls occur within the same
-                // millisecond.
-                let (seconds, mut nanos) = unix_time();
+                // Use the crate-provided ContextV7 to produce a Timestamp that
+                // carries a proper counter; this avoids the previous manual
+                // counter arithmetic and follows the crate's reseeding/monotonic logic.
+                let (seconds, nanos) = unix_time();
 
-                if let Some(ctx) = self.v7_context.as_mut() {
-                    // ctx = (last_seconds, last_nanos, counter)
-                    if ctx.0 == seconds && ctx.1 == nanos {
-                        // Same timestamp as previous; bump a small counter and
-                        // adjust the nanoseconds to preserve uniqueness.
-                        ctx.2 = ctx.2.saturating_add(1);
-                        // Add the counter value to the nanos, clamping under 1e9.
-                        nanos = nanos.saturating_add(ctx.2);
-                        if nanos >= 1_000_000_000 {
-                            nanos = 999_999_999;
-                        }
-                    } else {
-                        // New timestamp; reset the counter and record values.
-                        ctx.0 = seconds;
-                        ctx.1 = nanos;
-                        ctx.2 = 0;
-                    }
-                }
+                let ts = match self.v7_context.as_ref() {
+                    Some(ctx) => uuid::Timestamp::from_unix(ctx, seconds, nanos),
+                    None => uuid::Timestamp::from_unix(uuid::NoContext, seconds, nanos),
+                };
 
-                let ts = uuid::Timestamp::from_unix(uuid::NoContext, seconds, nanos);
                 uuid::Uuid::new_v7(ts).to_string()
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,15 @@ pub enum Language {
     C,
     Cxx,
 }
+/// Provide a `Default` implementation delegating to `new()` to satisfy clippy.
+impl Default for IncludeGuardGenerator {
+    /// Create a default `IncludeGuardGenerator`.
+    ///
+    /// @post Equivalent to `IncludeGuardGenerator::new()`.
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Enum representing line-ending styles.
 /// - `None`: Uses system default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,151 @@ pub enum LineEnding {
     CRLF,
 }
 
+/// Enum selecting UUID generation strategy.
+///
+/// - V7: Time-ordered UUID version 7 (preferred for ordered identifiers).
+/// - V4: Random UUID version 4.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum UuidKind {
+    V7,
+    V4,
+}
+
+/// Include guard generator struct.
+///
+/// @pre The `prefix` must be a non-empty string describing the guard prefix.
+/// @post Calling `generate(&mut self)` returns a well-formed include-guard text.
+/// @invariant The internal `v7_context` (if present) is private and used to ensure
+///            monotonic UUID v7 generation for short-interval repeated calls.
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen)]
+pub struct IncludeGuardGenerator {
+    // Private context used for UUID v7 generation to avoid collisions on rapid calls.
+    // Stored as (last_seconds, last_nanos, counter) to provide a small monotonic
+    // context without depending on internal uuid crate types.
+    v7_context: Option<(u64, u32, u32)>,
+}
+
+impl IncludeGuardGenerator {
+    /// Create a new `IncludeGuardGenerator`.
+    ///
+    /// @pre `prefix` must not be empty.
+    /// @post Returns an initialized generator configured to produce UUIDs of type `uuid_kind`.
+    /// Create a new `IncludeGuardGenerator` that holds only the internal context.
+    ///
+    /// The generator does not store prefix/suffix/language/line ending or UUID kind;
+    /// those are provided per-call to `generate` to allow callers to reuse the
+    /// same context while varying parameters.
+    pub fn new() -> Self {
+        IncludeGuardGenerator {
+            v7_context: Some((0u64, 0u32, 0u32)),
+        }
+    }
+
+    /// Generate the include guard string using the generator's configuration.
+    ///
+    /// @pre The generator was created via `new`.
+    /// @post Returns a textual include guard using the selected UUID generation method.
+    /// Generate the include guard string using the provided parameters.
+    ///
+    /// All parameters are supplied on each call so the same generator instance
+    /// can be reused with different prefixes/suffixes/UUID kinds.
+    pub fn generate(
+        &mut self,
+        prefix: String,
+        suffix: Option<String>,
+        language: Language,
+        line_ending: LineEnding,
+        uuid_kind: UuidKind,
+    ) -> String {
+        // Generate a UUID string according to the selected kind.
+        let uuid_string = match uuid_kind {
+            UuidKind::V4 => uuid::Uuid::new_v4().to_string(),
+            UuidKind::V7 => {
+                // Use the existing `unix_time` helper to get seconds and subsecond
+                // component. Maintain a tiny local context (last timestamp + counter)
+                // to avoid collisions when multiple calls occur within the same
+                // millisecond.
+                let (mut seconds, mut nanos) = unix_time();
+
+                if let Some(ctx) = self.v7_context.as_mut() {
+                    // ctx = (last_seconds, last_nanos, counter)
+                    if ctx.0 == seconds && ctx.1 == nanos {
+                        // Same timestamp as previous; bump a small counter and
+                        // adjust the nanoseconds to preserve uniqueness.
+                        ctx.2 = ctx.2.saturating_add(1);
+                        // Add the counter value to the nanos, clamping under 1e9.
+                        nanos = nanos.saturating_add(ctx.2);
+                        if nanos >= 1_000_000_000 {
+                            nanos = 999_999_999;
+                        }
+                    } else {
+                        // New timestamp; reset the counter and record values.
+                        ctx.0 = seconds;
+                        ctx.1 = nanos;
+                        ctx.2 = 0;
+                    }
+                }
+
+                let ts = uuid::Timestamp::from_unix(uuid::NoContext, seconds, nanos);
+                uuid::Uuid::new_v7(ts).to_string()
+            }
+        };
+
+        // Format guard pieces and return the assembled include-guard text.
+        let uuid = uuid_string.replace('-', "_").to_uppercase();
+        let mut guard = vec![prefix, uuid.clone()];
+
+        // If a suffix was provided, append it to the guard components.
+        if let Some(s) = &suffix {
+            guard.push(s.clone());
+        }
+
+        let guard = guard.join("_");
+
+        let ifndef = format!("#ifndef {}", guard);
+        let define = format!("#define {}", guard);
+        let endif = format!("#endif /* {} */", guard);
+
+        let mut text = vec![ifndef, define];
+
+        // If the target language is C, add extern "C" compatibility blocks.
+        // This branch ensures C consumers get the correct linkage annotations.
+        if let Language::C = language {
+            let extern_c: Vec<String> = vec![
+                "".to_string(), // blank line
+                "#ifdef __cplusplus".to_string(),
+                "extern \"C\" {".to_string(),
+                "#endif /* __cplusplus */".to_string(),
+                "".to_string(), // blank line
+                "#ifdef __cplusplus".to_string(),
+                "} /* extern \"C\" */".to_string(),
+                "#endif /* __cplusplus */".to_string(),
+                "".to_string(), // blank line
+            ];
+            text.extend(extern_c);
+        }
+
+        text.push(endif);
+        text.push("".to_string());
+
+        let newline = match line_ending {
+            LineEnding::LF => "\n",
+            LineEnding::CRLF => "\r\n",
+            LineEnding::None => {
+                // Qualitative explanation: pick system default line ending.
+                if cfg!(target_os = "windows") {
+                    "\r\n"
+                } else {
+                    "\n"
+                }
+            }
+        }
+        .to_string();
+
+        text.join(&newline)
+    }
+}
+
 /// Generates an include guard string with optional language-specific modifications.
 ///
 /// # Arguments
@@ -49,61 +194,9 @@ pub fn generate_guard(
     x: Language,
     line_ending: LineEnding,
 ) -> String {
-    // Generate a UUID and format it for use in the include guard.
-    let uuid = generate().to_string().replace('-', "_").to_uppercase();
-    let mut guard = vec![prefix, uuid];
-
-    // Append suffix if provided.
-    if let Some(suffix) = suffix {
-        guard.push(suffix);
-    }
-
-    // Join guard components with underscores.
-    let guard = guard.join("_");
-
-    // Define standard include guard macros.
-    let ifndef = format!("#ifndef {}", guard);
-    let define = format!("#define {}", guard);
-    let endif = format!("#endif /* {} */", guard);
-
-    let mut text = vec![ifndef, define];
-
-    // If the target language is C, add `extern "C"` blocks for compatibility.
-    if let Language::C = x {
-        let extern_c: Vec<String> = vec![
-            "".to_string(), // blank line
-            "#ifdef __cplusplus".to_string(),
-            "extern \"C\" {".to_string(),
-            "#endif /* __cplusplus */".to_string(),
-            "".to_string(), // blank line
-            "#ifdef __cplusplus".to_string(),
-            "} /* extern \"C\" */".to_string(),
-            "#endif /* __cplusplus */".to_string(),
-            "".to_string(), // blank line
-        ];
-        text.extend(extern_c);
-    }
-
-    // Append closing `#endif` statement.
-    text.push(endif);
-    text.push("".to_string());
-
-    // Determine the newline character based on the specified line-ending format.
-    let newline = match line_ending {
-        LineEnding::LF => "\n",
-        LineEnding::CRLF => "\r\n",
-        LineEnding::None => {
-            if cfg!(target_os = "windows") {
-                "\r\n"
-            } else {
-                "\n"
-            }
-        }
-    }
-    .to_string();
-
-    // Join all lines with the appropriate newline character.
-    text.join(&newline)
+    // Use the new struct-based API (default to UUID v7 for compatibility).
+    let mut generator = IncludeGuardGenerator::new();
+    generator.generate(prefix, suffix, x, line_ending, UuidKind::V7)
 }
 
 fn unix_time() -> (u64, u32) {
@@ -126,13 +219,6 @@ fn unix_time() -> (u64, u32) {
         let nanos = now.subsec_millis() * 1_000_000;
         (seconds, nanos)
     }
-}
-
-fn generate() -> uuid::Uuid {
-    let (seconds, millis) = unix_time();
-    let ts = uuid::Timestamp::from_unix(uuid::NoContext, seconds, millis);
-
-    uuid::Uuid::new_v7(ts)
 }
 
 #[cfg(test)]
@@ -210,5 +296,68 @@ mod tests {
         assert!(result.contains("#ifdef __cplusplus"));
         assert!(result.contains("extern \"C\" {"));
         assert!(result.contains("} /* extern \"C\" */"));
+    }
+
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    fn test_include_guard_generator_v7_uniqueness() {
+        let mut generator = IncludeGuardGenerator::new();
+
+        let r1 = generator.generate(
+            "TEST".to_string(),
+            None,
+            Language::None,
+            LineEnding::LF,
+            UuidKind::V7,
+        );
+        let r2 = generator.generate(
+            "TEST".to_string(),
+            None,
+            Language::None,
+            LineEnding::LF,
+            UuidKind::V7,
+        );
+
+        let u1 = extract_uuids(r1.as_str())[0].clone();
+        let u2 = extract_uuids(r2.as_str())[0].clone();
+
+        // Two successive calls should produce distinct UUIDs.
+        assert_ne!(u1, u2);
+    }
+
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    fn test_include_guard_generator_v4_and_short_interval() {
+        // Test UUID v4 selection produces valid-looking UUIDs and uniqueness across calls.
+        let mut g_v4 = IncludeGuardGenerator::new();
+
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..8 {
+            let r = g_v4.generate(
+                "TEST".to_string(),
+                None,
+                Language::None,
+                LineEnding::LF,
+                UuidKind::V4,
+            );
+            let u = extract_uuids(r.as_str())[0].clone();
+            assert!(seen.insert(u), "Duplicate UUID found for v4 generator");
+        }
+
+        // Test rapid successive v7 calls are unique.
+        let mut g_v7 = IncludeGuardGenerator::new();
+
+        let mut seen_v7 = std::collections::HashSet::new();
+        for _ in 0..16 {
+            let r = g_v7.generate(
+                "TEST".to_string(),
+                None,
+                Language::None,
+                LineEnding::LF,
+                UuidKind::V7,
+            );
+            let u = extract_uuids(r.as_str())[0].clone();
+            assert!(seen_v7.insert(u), "Duplicate UUID found for v7 generator");
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ impl IncludeGuardGenerator {
                 // component. Maintain a tiny local context (last timestamp + counter)
                 // to avoid collisions when multiple calls occur within the same
                 // millisecond.
-                let (mut seconds, mut nanos) = unix_time();
+                let (seconds, mut nanos) = unix_time();
 
                 if let Some(ctx) = self.v7_context.as_mut() {
                     // ctx = (last_seconds, last_nanos, counter)

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,12 +117,15 @@ fn main() {
     // Parse command-line arguments using `clap`.
     let args = Args::parse();
 
-    // Generate the include guard based on user input.
-    let guard = guardgen_lib::generate_guard(
+    // Generate the include guard based on user input using the struct-based API.
+    // For now, default to UUID v7 generation for compatibility.
+    let mut generator = guardgen_lib::IncludeGuardGenerator::new();
+    let guard = generator.generate(
         args.prefix,
         args.suffix,
         args.x.into(),
         args.line_ending.into(),
+        guardgen_lib::UuidKind::V7,
     );
 
     if let Some(file_path) = &args.filename {


### PR DESCRIPTION
## Summary:
- Refactors the function-based include-guard generator into a reusable, stateful struct API and adds selectable UUID generation (`v7` or `v4`).
- The generator privately holds a minimal UUID v7 context to ensure safe, short-interval repeated calls. All other parameters (prefix, suffix, language, line ending, UUID kind) are provided per-call to `generate()`.

## Key changes:
- Added `IncludeGuardGenerator` and `UuidKind` in lib.rs.
  - New API: `IncludeGuardGenerator::new()` + `generate(prefix, suffix, language, line_ending, uuid_kind)`.
- Kept `generate_guard(...)` as a thin compatibility wrapper that delegates to the new API.
- Updated CLI use in main.rs to call the struct-based API.
- Added unit tests for `v7`/`v4` selection and short-interval uniqueness.
- Minor internal refactor to avoid depending on uuid crate internals (small monotonic context stored inside the struct).

## Compatibility:
- Backward-compatible: `generate_guard(...)` remains available and behaves unchanged.
- Default behavior remains UUID v7 to preserve existing output.
- Consumers can migrate to `IncludeGuardGenerator` to reuse the internal context and explicitly choose `UuidKind::V4` or `UuidKind::V7`.

## Tests & verification:
- Local native tests: `cargo test --all-features` — all unit tests pass.
- WASM targets compiled successfully (`wasm32-unknown-unknown`, `wasm32-wasip2`). CI workflow rust-ci-wasm.yml covers wasm builds/tests.
- New tests added to validate uniqueness across rapid calls and both UUID kinds.

## How to test locally:
```bash
cargo test --all-features
rustup target add wasm32-unknown-unknown wasm32-wasip2
cargo build --target wasm32-unknown-unknown
cargo build --target wasm32-wasip2

# If you have wasm-pack + a browser installed:
wasm-pack test --headless --firefox
```

## Notes / Next steps:
- Regenerate WASM bindings (`wasm-pack build` / wasm-bindgen) and update pkg if publishing the JS/WASM package.
- Add a CLI flag to select UUID version (e.g., `--uuid-version v4|v7`) and document the new API.
- After deprecation period, remove the old function-based API and update docs/examples.