### PR TITLE
Export UuidKind enum for wasm bindings in version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-05-28
+
+### Fixed
+
+- Export `UuidKind` enum from the library API to allow wasm bindings to specify the UUID generation kind (v4 or v7).
+
 ## [2.0.0] - 2026-05-28
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub enum LineEnding {
 ///
 /// - V7: Time-ordered UUID version 7 (preferred for ordered identifiers).
 /// - V4: Random UUID version 4.
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum UuidKind {
     V7,


### PR DESCRIPTION
- Added `UuidKind` enum to the library API to enable specification of UUID generation kind (v4 or v7) for wasm bindings.
- Updated CHANGELOG to reflect the new export in version 2.1.0.